### PR TITLE
Add timestamp to CSV output

### DIFF
--- a/.github/workflows/schedule_pipeline.yml
+++ b/.github/workflows/schedule_pipeline.yml
@@ -46,5 +46,5 @@ jobs:
         with:
           name: aggregated-stock-data
           # run_pipeline.py가 생성하는 실제 위치와 일치
-          path: output/aggregated/aggregated_stock_data.csv
+          path: output/aggregated/aggregated_stock_data_*.csv
           retention-days: 5

--- a/backend/run_pipeline.py
+++ b/backend/run_pipeline.py
@@ -350,7 +350,9 @@ def aggregate_and_save_to_csv(new_articles, output_dir):
             final_df[col] = final_df[col].apply(lambda x: str(x) if isinstance(x, list) else str(x))
 
     os.makedirs(output_dir, exist_ok=True)
-    csv_path = os.path.join(output_dir, "aggregated_stock_data.csv")
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    csv_filename = f"aggregated_stock_data_{timestamp}.csv"
+    csv_path = os.path.join(output_dir, csv_filename)
     final_df.to_csv(csv_path, index=False, encoding='utf-8-sig', quoting=csv.QUOTE_ALL)
     print(f"--- ✅ CSV 저장 완료. 총 {len(final_df)}개 기사 저장 ---")
     print(f"   - 저장 경로: {csv_path}")


### PR DESCRIPTION
## Summary
- append timestamp to CSV filename during pipeline run
- update action artifact path to match new filenames

## Testing
- `python -m py_compile backend/run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_688aa9c4c5c88323a28aa38691eceacc