### PR TITLE
Add missing csv import to pipeline

### DIFF
--- a/backend/run_pipeline.py
+++ b/backend/run_pipeline.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import re
 import warnings
 import urllib3
+import csv
 
 # --- 필수 라이브러리 임포트 ---
 import requests


### PR DESCRIPTION
## Summary
- import csv in run_pipeline to allow CSV export without NameError

## Testing
- `python -m py_compile backend/run_pipeline.py`
- `python - <<'PY'
from backend.run_pipeline import aggregate_and_save_to_csv
import os
os.makedirs('backend/output/aggregated', exist_ok=True)
articles=[{'url':'http://example.com','published_at':'2024-05-01','analysis_orgs':['Org1'], 'analysis_keywords':['kw1'], 'title':'Title','content':'content'}]
aggregate_and_save_to_csv(articles,'backend/output/aggregated')
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ff1ba4eac8323a423f8a705ce3af1